### PR TITLE
fix: dev broken on windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,7 @@
 /packages/father-doc/src/fixtures/e2e/normal/.docz
 /.changelog
 yarn.lock
+package-lock.json
 dist
+/src
+/.vscode

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To check out live examples and docs, visit [father-doc GitHub Pages](https://umi
 ```bash
 $ npm install
 $ npm run bootstrap
-$ npm run dev
 $ npm run build
+$ npm run dev
 $ npm run test
 ```

--- a/lerna.json
+++ b/lerna.json
@@ -18,6 +18,5 @@
       "exact": true
     }
   },
-  "npmClient": "yarn",
   "version": "independent"
 }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "private": true,
   "scripts": {
-    "dev": "BROWSER=none node ./packages/father-doc/bin/father-doc.js dev",
-    "doc:build": "BROWSER=none node ./packages/father-doc/bin/father-doc.js build",
+    "dev": "cross-env BROWSER=none node ./packages/father-doc/bin/father-doc.js dev",
+    "doc:build": "cross-env BROWSER=none node ./packages/father-doc/bin/father-doc.js build",
     "doc:deploy": "bash ./scripts/deploy_doc.sh",
     "bootstrap": "lerna bootstrap",
     "build": "father-build build",
@@ -17,6 +17,7 @@
     "@types/jest": "^24.0.13",
     "antd": "^3.25.3",
     "babel-plugin-import": "^1.13.0",
+    "cross-env": "^6.0.3",
     "father-build": "^1.14.2",
     "lerna": "^3.6.0",
     "lerna-changelog": "^0.8.2",

--- a/packages/umi-plugin-father-doc/package.json
+++ b/packages/umi-plugin-father-doc/package.json
@@ -49,7 +49,8 @@
     "umi-types": "^0.5.4",
     "unified": "^8.4.1",
     "unist-util-visit": "^2.0.1",
-    "unist-util-visit-parents": "^3.0.1"
+    "unist-util-visit-parents": "^3.0.1",
+    "upath": "^1.2.0"
   },
   "devDependencies": {
     "@types/history": "^4.7.3"

--- a/packages/umi-plugin-father-doc/src/routes/getMenuFromRoutes.ts
+++ b/packages/umi-plugin-father-doc/src/routes/getMenuFromRoutes.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'upath';
 import { IApi } from 'umi-types';
 
 export interface IMenuItem {

--- a/packages/umi-plugin-father-doc/src/routes/getRouteConfig.ts
+++ b/packages/umi-plugin-father-doc/src/routes/getRouteConfig.ts
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import path from 'path';
+import path from 'upath';
 import { IApi, IRoute } from 'umi-types';
 import deepmerge from 'deepmerge';
 import getFrontMatter from './getFrontMatter';

--- a/packages/umi-plugin-father-doc/src/routes/getRouteConfigFromDir.ts
+++ b/packages/umi-plugin-father-doc/src/routes/getRouteConfigFromDir.ts
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import path from 'path';
+import path from 'upath';
 import { IRoute } from 'umi-types';
 
 /**

--- a/packages/umi-plugin-father-doc/src/transformer/index.ts
+++ b/packages/umi-plugin-father-doc/src/transformer/index.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'upath';
 import getYamlConfig from 'umi-build-dev/lib/routes/getYamlConfig';
 import remark from './remark';
 


### PR DESCRIPTION
项目在 windows 下启动开发，有如下问题：

#### 构建脚本问题
  - README.md 中 bash 引导有误
  - lerna 中 npmClient 不符
  - windows 下缺少 cross-env
  - .gitingore 没有 .umi

#### windows 下 path 问题
暂时使用 upath 来统一 '\' 和 '/'，值得再考虑


#### FRONT_MATTER_EXP  正则空格问题
此条未修复