### PR TITLE
fix: html tags in desc

### DIFF
--- a/packages/umi-plugin-father-doc/package.json
+++ b/packages/umi-plugin-father-doc/package.json
@@ -33,6 +33,7 @@
     "deepmerge": "^4.2.2",
     "hast-util-to-html": "^6.0.2",
     "hast-util-to-string": "^1.0.2",
+    "innertext":"^1.0.3",
     "hosted-git-info": "^3.0.2",
     "intersection-observer": "^0.7.0",
     "js-yaml": "^3.13.1",

--- a/packages/umi-plugin-father-doc/src/themes/default/previewer.tsx
+++ b/packages/umi-plugin-father-doc/src/themes/default/previewer.tsx
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import Clipboard from 'react-clipboard.js';
+import innertext from 'innertext';
 import finaliseCSB, { parseImport, issueLink } from '../../utils/codesandbox';
 import localePropsHoc from './localePropsHoc';
 import './previewer.less';
@@ -85,7 +86,7 @@ ${issueLink}`,
         devDependencies: {
           typescript: '3.3.3',
         },
-        desc,
+        desc: innertext(desc || ''),
         template: 'create-react-app-typescript',
         fileName: 'demo.tsx',
       };
@@ -116,7 +117,7 @@ ${issueLink}`,
         devDependencies: {
           typescript: '3.3.3',
         },
-        desc,
+        desc: innertext(desc || ''),
         template: 'create-react-app',
         fileName: 'demo.jsx',
       };

--- a/packages/umi-plugin-father-doc/src/themes/typings/typings.d.ts
+++ b/packages/umi-plugin-father-doc/src/themes/typings/typings.d.ts
@@ -1,1 +1,2 @@
 declare module '*.less';
+declare module 'innertext';


### PR DESCRIPTION
独立 demo 的 desc 是带有 html tags 的字符串，带 tags 传到 codesandbox 会报错，strip 掉了